### PR TITLE
Updated Vagrantfile for Vagrant API version 2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,16 @@
-Vagrant::Config.run do |config|
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+	# base settings
 	config.vm.box = "debian"
 	config.vm.box_url = "https://dl.dropbox.com/u/30949096/debian.box"
-	config.vm.network :bridged
-	config.vm.customize ["modifyvm", :id, "--memory", 512]
+	config.vm.network "forwarded_port", guest: 80, host: 8080
+	# virtualbox specific customisation(s)
+	config.vm.provider "virtualbox" do |v|
+		v.customize ["modifyvm", :id, "--memory", "512"]
+		v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+	end
+	# puppet provisioning
 	config.vm.provision :puppet do |puppet|
 		puppet.manifests_path = "manifests"
 		puppet.manifest_file = "fortrabbit.pp"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	# base settings
 	config.vm.box = "debian"
 	config.vm.box_url = "https://dl.dropbox.com/u/30949096/debian.box"
-	config.vm.network "forwarded_port", guest: 80, host: 8080
+	config.vm.network "public_network"
 	# virtualbox specific customisation(s)
 	config.vm.provider "virtualbox" do |v|
 		v.customize ["modifyvm", :id, "--memory", "512"]


### PR DESCRIPTION
Updates to latest Vagrant API version - provider specific code (in this case for virtual box) is now self-contained as per the new spec
